### PR TITLE
Update dependencies for v8.0.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,21 @@ source:
   sha256: a713ff7e10ce69f9f51bc158330829f2196220e2755ae8a720def37ce1db4841
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - jupyter_packaging
+    - jupyterlab >=3.1,<4
     - pip
-    - python >=3.6
+    - python >=3.7
   run:
     - h5grove =1.3.0
     - h5py >=3.5
-    - jupyter_server >=1.6,<2
-    - python >=3.6
+    - jupyter_server >=1.6,<3
+    - python >=3.7
     - ipython
 
 test:


### PR DESCRIPTION
**!!!This PR should NOT BE MERGED !!!**

It prepares a branch to maintain jupyterlab-h5web v8.0.0.
It update dependencies to:
- allow using `jupyter_server` v2 at runtime (as jupyterlab v3 does)
- use `jupyterlab` v3 for build

Documentation on maintaining multiple versions is here: https://conda-forge.org/docs/maintainer/updating_pkgs.html#maintaining-several-versions

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
